### PR TITLE
Move dev dependencies back in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "author": "Alan Shortis <alan.shortis@mac.com>",
   "license": "MIT",
   "dependencies" : {
+  },
+  "devDependencies": {
     "del": "^2.2.2",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.1",
@@ -14,9 +16,6 @@
     "gulp-sass": "^3.1.0",
     "gulp-util": "^3.0.8",
     "node-notifier": "^5.0.2"
-  },
-  "devDependencies": {
-
   },
   "scripts": {
     "postinstall": "./node_modules/.bin/gulp",


### PR DESCRIPTION
To get them installed on Dokku, use:

`dokku config:set appname NPM_CONFIG_PRODUCTION=false`

And it will install dev dependencies.